### PR TITLE
Modified definition for "ordered_options"

### DIFF
--- a/schema/herocard-response-schema.json
+++ b/schema/herocard-response-schema.json
@@ -221,13 +221,18 @@
         "format":          {"type": "string", "description": "The type of the user input"},
         "display_content": {"type": "string", "description": "Content to be displayed with the user input field to further explain or prompt it"},
         "options":         {"type": "object", "description": "Options to present when format is select."},
-        "ordered_options": [{"type": "object", "description": "Options specifically ordered to present more than 1 value."}],
+        "ordered_options": {"type": "array", "items": {"$ref": "#/definitions/option"}, "description": "Options specifically ordered to present more than 1 value."},
         "min_length":      {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
         "max_length":      {"type": "integer", "minimum": 0, "description": "The maximum length of the field"},
         "min_value":       {"type": "integer", "description": "The minimum value of the field (for numeric types). If none provided, default is 1."},
         "max_value":       {"type": "integer", "description": "The maximum value of the field (for numeric types). If none provided, default is 5."}
       },
       "required": ["id", "label"]
+    },
+    
+    "option": {
+      "type": "object",
+      "additionalProperties" : {"type": "string"}
     },
 
     "sticky": {

--- a/schema/herocard-response-schema.json
+++ b/schema/herocard-response-schema.json
@@ -221,7 +221,7 @@
         "format":          {"type": "string", "description": "The type of the user input"},
         "display_content": {"type": "string", "description": "Content to be displayed with the user input field to further explain or prompt it"},
         "options":         {"type": "object", "description": "Options to present when format is select."},
-        "ordered_options": {"type": "array", "items": {"$ref": "#/definitions/option"}, "description": "Options specifically ordered to present more than 1 value."},
+        "ordered_options": {"type": "array", "items": {"$ref": "#/definitions/option"}, "minItems": 1, "description": "Options specifically ordered to present more than 1 value."},
         "min_length":      {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
         "max_length":      {"type": "integer", "minimum": 0, "description": "The maximum length of the field"},
         "min_value":       {"type": "integer", "description": "The minimum value of the field (for numeric types). If none provided, default is 1."},


### PR DESCRIPTION
It needs to be an array of dictionaries and before it was just an array. This has been approved by 3 developers.
Signed-off-by: Jossie McManus jossie.mcmanus@gmail.com